### PR TITLE
[CHORE] CRYINGCRYING_QA

### DIFF
--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/home/ThunderDetailActivity.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/home/ThunderDetailActivity.kt
@@ -18,10 +18,12 @@ import com.playtogether_android.app.presentation.ui.message.ChattingActivity
 import com.playtogether_android.app.presentation.ui.thunder.ApplicantListAdapter
 import com.playtogether_android.app.presentation.ui.thunder.viewmodel.ThunderDetailViewModel
 import com.playtogether_android.app.presentation.ui.userInfo.OtherInfoActivity
+import com.playtogether_android.app.presentation.ui.userInfo.viewmodel.UserInfoViewModel
 import com.playtogether_android.app.util.CustomDialog
 import com.playtogether_android.app.util.CustomDialogSon
 import com.playtogether_android.app.util.shortToast
 import com.playtogether_android.app.util.showCustomPopUp
+import com.playtogether_android.data.singleton.PlayTogetherRepository
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
@@ -29,6 +31,7 @@ import timber.log.Timber
 class ThunderDetailActivity :
     BaseActivity<ActivityThunderDetailBinding>(R.layout.activity_thunder_detail) {
     private val thunderDetailViewModel: ThunderDetailViewModel by viewModels()
+    private val userInfoViewModel: UserInfoViewModel by viewModels()
     private lateinit var applicantListAdapter: ApplicantListAdapter
     private val homeViewModel: HomeViewModel by viewModels()
     private var organizerId: Int = -1
@@ -197,6 +200,13 @@ class ThunderDetailActivity :
             applicantListAdapter.notifyDataSetChanged()
         }
 
+        applicantListAdapter.itemClick = object : ApplicantListAdapter.ItemClick {
+            override fun onClick(view: View, position: Int, userId: Int) {
+                userInfoViewModel.getOtherInfo(PlayTogetherRepository.crewId, userId)
+                val intent = Intent(this@ThunderDetailActivity, OtherInfoActivity::class.java)
+
+            }
+        }
     }
 
     private fun checkCategory() {

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/home/ThunderDetailActivity.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/home/ThunderDetailActivity.kt
@@ -217,7 +217,8 @@ class ThunderDetailActivity :
             binding.clThunderdetailMessage,
             binding.ivThunderdetailLike,
             binding.tvThunderdetailReport,
-            binding.clThunderdetailApplyBtn
+            binding.clThunderdetailApplyBtn,
+            binding.clThunderApplicantContent
         )
 
         thunderDetailViewModel.isThunderType.observe(this) {

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/home/ThunderDetailActivity.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/home/ThunderDetailActivity.kt
@@ -196,6 +196,7 @@ class ThunderDetailActivity :
             applicantListAdapter.applicantList.addAll(it)
             applicantListAdapter.notifyDataSetChanged()
         }
+
     }
 
     private fun checkCategory() {
@@ -205,20 +206,19 @@ class ThunderDetailActivity :
             binding.clDetailBoundary,
             binding.clDetailOrganizerContainer,
             binding.tvThunderdetailReport,
-            binding.clThunderApplicantContent
+            binding.clThunderApplicantContent,
         )
         val openCategory = mutableListOf(
             binding.ivDetailOption,
             binding.clDetailOrganizerContainer,
             binding.clDetailBoundary,
-            binding.clThunderApplicantContent
+            binding.clThunderApplicantContent,
         )
         val defaultCategory = mutableListOf(
             binding.clThunderdetailMessage,
             binding.ivThunderdetailLike,
             binding.tvThunderdetailReport,
             binding.clThunderdetailApplyBtn,
-            binding.clThunderApplicantContent
         )
 
         thunderDetailViewModel.isThunderType.observe(this) {

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/home/adapter/HomeHotAdapter.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/home/adapter/HomeHotAdapter.kt
@@ -11,6 +11,7 @@ import com.playtogether_android.app.presentation.ui.home.ThunderDetailActivity
 import com.playtogether_android.app.util.ListAdapterComparator
 import com.playtogether_android.app.util.stringListBuilder
 import com.playtogether_android.domain.model.light.CategoryData
+import timber.log.Timber
 
 class HomeHotAdapter :
     ListAdapter<CategoryData, HomeHotAdapter.ViewHolder>(ListAdapterComparator<CategoryData>()) {
@@ -28,11 +29,17 @@ class HomeHotAdapter :
                 val context = itemView.context
                 categoryData = item
                 tvHomenewDate.text =
-                    context.stringListBuilder(context, listOf(item.date, item.place, item.time))
+                    context.stringListBuilder(
+                        context,
+                        listOf(item.date, " ", item.place, " ", item.time)
+                    )
                 tvHomenewPeopleCnt.text = context.stringListBuilder(
                     context,
                     listOf(item.lightMemberCnt.toString(), "/", item.peopleCnt.toString())
                 )
+                Timber.e("item date : ${item.date}")
+                Timber.e("item place : ${item.place}")
+                Timber.e("item time : ${item.time}")
             }
         }
     }
@@ -49,7 +56,7 @@ class HomeHotAdapter :
 
         if (itemClick != null) {
             holder.itemView.setOnClickListener {
-                itemClick?.onClick(it,position,item.lightId)
+                itemClick?.onClick(it, position, item.lightId)
             }
         }
     }

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/home/adapter/HomeNewAdapter.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/home/adapter/HomeNewAdapter.kt
@@ -11,6 +11,7 @@ import com.playtogether_android.app.presentation.ui.home.ThunderDetailActivity
 import com.playtogether_android.app.util.ListAdapterComparator
 import com.playtogether_android.app.util.stringListBuilder
 import com.playtogether_android.domain.model.light.CategoryData
+import timber.log.Timber
 
 class HomeNewAdapter :
     ListAdapter<CategoryData, HomeNewAdapter.ViewHolder>(ListAdapterComparator<CategoryData>()) {
@@ -28,11 +29,17 @@ class HomeNewAdapter :
                 categoryData = item
                 val context = itemView.context
                 tvHomenewDate.text =
-                    context.stringListBuilder(context, listOf(item.date, item.place, item.time))
+                    context.stringListBuilder(
+                        context,
+                        listOf(item.date, " ", item.place, " ", item.time)
+                    )
                 tvHomenewPeopleCnt.text = context.stringListBuilder(
                     context,
                     listOf(item.lightMemberCnt.toString(), "/", item.peopleCnt.toString())
                 )
+                Timber.e("item date : ${item.date}")
+                Timber.e("item place : ${item.place}")
+                Timber.e("item time : ${item.time}")
             }
         }
     }

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/login/LoginActivity.kt
@@ -84,6 +84,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
 //                .getAccessToken(account.serverAuthCode!!)
             with(signViewModel) {
                 googleLogin()
+                Timber.e("google-login : ${PlayTogetherRepository.googleUserToken}")
                 isLogin.observe(this@LoginActivity) { success ->
                     if (success) {
                         Timber.e("login : 구글 로그인 성공")
@@ -136,15 +137,15 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
     private fun observeCrewList(size: Int) {
         val crewId = PlayTogetherRepository.crewId
         if (signViewModel.signup) {
-            //TODO: 회원가입했고 현재 등록된 crewId가 있음
-            if (crewId != -1) {
-                val intent = Intent(this@LoginActivity, MainActivity::class.java)
-                nextActivity(intent)
-            }
-            // TODO: 회원이지만 재설치를 해서 preference가 비어있음 -> 가입한 동아리 선택뷰로 이동
-            else if (crewId == -1 && size > 0) {
+            // TODO: 회원이지만 재설치를 해서 preference가 비어있음 또는 로그아웃한 경우-> 가입한 동아리 선택뷰로 이동
+            if (crewId == -1 && size > 0) {
                 val intent =
                     Intent(this@LoginActivity, OnboardingReDownLoadActivity::class.java)
+                nextActivity(intent)
+            }
+            //TODO: 회원가입했고 현재 등록된 crewId가 있음
+            else if (crewId != -1) {
+                val intent = Intent(this@LoginActivity, MainActivity::class.java)
                 nextActivity(intent)
             }
             // TODO: 회원이지만 가입한 동아리가 없는 경우

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/login/LoginActivity.kt
@@ -17,11 +17,13 @@ import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.AuthErrorCause
 import com.kakao.sdk.common.util.Utility
 import com.kakao.sdk.user.UserApiClient
+import com.playtogether_android.app.BuildConfig
 import com.playtogether_android.app.R
 import com.playtogether_android.app.databinding.ActivityLoginBinding
 import com.playtogether_android.app.presentation.base.BaseActivity
 import com.playtogether_android.app.presentation.ui.home.viewmodel.HomeViewModel
 import com.playtogether_android.app.presentation.ui.login.view.LoginTermsActivity
+import com.playtogether_android.app.presentation.ui.login.viewmodel.GoogleLoginRepository
 import com.playtogether_android.app.presentation.ui.main.MainActivity
 import com.playtogether_android.app.presentation.ui.onboarding.OnboardingReDownLoadActivity
 import com.playtogether_android.app.presentation.ui.onboarding.SelectOnboardingActivity
@@ -77,11 +79,11 @@ class LoginActivity : BaseActivity<ActivityLoginBinding>(R.layout.activity_login
     private fun handleSignInResult(task: Task<GoogleSignInAccount>) {
         try {
             val account = task.getResult(ApiException::class.java)
-//            val clientId = BuildConfig.GOOGLE_CLIENT_ID
-//            val clientSecret = BuildConfig.GOOGLE_CLIENT_SECRET
-//
-//            GoogleLoginRepository(clientId, clientSecret)
-//                .getAccessToken(account.serverAuthCode!!)
+            val clientId = BuildConfig.GOOGLE_CLIENT_ID
+            val clientSecret = BuildConfig.GOOGLE_CLIENT_SECRET
+            GoogleLoginRepository(clientId, clientSecret)
+                .getAccessToken(account.serverAuthCode!!)
+
             with(signViewModel) {
                 googleLogin()
                 Timber.e("google-login : ${PlayTogetherRepository.googleUserToken}")

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/login/view/LoginTermsActivity.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/login/view/LoginTermsActivity.kt
@@ -54,7 +54,10 @@ class LoginTermsActivity : BaseActivity<ActivityLoginTermsBinding>(R.layout.acti
         for (item in textList) {
             item.setOnClickListener {
                 Intent(this, WebViewActivity::class.java).apply {
-                    putExtra("url", "www.naver.com")
+                    putExtra(
+                        "url",
+                        "https://cheddar-liquid-051.notion.site/fc9dae6b1917453bbb1a39c4be4e4297"
+                    )
                     startActivity(this)
                 }
             }

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/mypage/MyPageSettingActivity.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/mypage/MyPageSettingActivity.kt
@@ -64,7 +64,13 @@ class MyPageSettingActivity :
 
         //로그아웃
         binding.tvSettingLogout.setOnClickListener {
-            PlayTogetherRepository.userLogin = false
+            with(PlayTogetherRepository) {
+                //todo 로그아웃한 경우 남아있는 Preferenece를 제거해야 소셜로그인 번갈아가면서 사용할 때 좋을거같아서 수정합니다.
+                crewId = -1
+                crewName = ""
+                userLogin = false
+            }
+
             Intent(this, LoginActivity::class.java).apply {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/thunder/ApplicantListAdapter.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/thunder/ApplicantListAdapter.kt
@@ -1,9 +1,11 @@
 package com.playtogether_android.app.presentation.ui.thunder
 
+import android.content.Intent
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.playtogether_android.app.databinding.ItemThunderApplicantListBinding
+import com.playtogether_android.app.presentation.ui.userInfo.OtherInfoActivity
 import com.playtogether_android.domain.model.home.ThunderJoinEndMember
 import com.playtogether_android.domain.model.thunder.Member
 
@@ -26,7 +28,16 @@ class ApplicantListAdapter : RecyclerView.Adapter<ApplicantListAdapter.Applicant
     }
 
     override fun onBindViewHolder(holder: ApplicantListViewHolder, position: Int) {
-        holder.onBind(applicantList[position])
+        val item = applicantList[position]
+        holder.onBind(item)
+        holder.itemView.apply {
+            //todo 근데 본인일때는 어케 알고 처리를 하지?
+            setOnClickListener { view ->
+                val intent = Intent(this.context, OtherInfoActivity::class.java)
+                intent.putExtra("memberId", item.userId)
+                this.context.startActivity(intent)
+            }
+        }
     }
 
     override fun getItemCount(): Int = applicantList.size

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/thunder/ApplicantListAdapter.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/thunder/ApplicantListAdapter.kt
@@ -1,18 +1,23 @@
 package com.playtogether_android.app.presentation.ui.thunder
 
-import android.content.Intent
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.playtogether_android.app.databinding.ItemThunderApplicantListBinding
-import com.playtogether_android.app.presentation.ui.userInfo.OtherInfoActivity
-import com.playtogether_android.domain.model.home.ThunderJoinEndMember
 import com.playtogether_android.domain.model.thunder.Member
 
 class ApplicantListAdapter : RecyclerView.Adapter<ApplicantListAdapter.ApplicantListViewHolder>() {
 
-//    private val _applicantList = mutableListOf<TempApplicantData.UserList>()
+    //    private val _applicantList = mutableListOf<TempApplicantData.UserList>()
 //    var applicantList: List<TempApplicantData.UserList> = _applicantList
+
+    interface ItemClick {
+        fun onClick(view: View, position: Int, userId: Int)
+    }
+
+    var itemClick: ApplicantListAdapter.ItemClick? = null
+
 
     val applicantList = mutableListOf<Member>()
 
@@ -30,14 +35,20 @@ class ApplicantListAdapter : RecyclerView.Adapter<ApplicantListAdapter.Applicant
     override fun onBindViewHolder(holder: ApplicantListViewHolder, position: Int) {
         val item = applicantList[position]
         holder.onBind(item)
-        holder.itemView.apply {
-            //todo 근데 본인일때는 어케 알고 처리를 하지?
-            setOnClickListener { view ->
-                val intent = Intent(this.context, OtherInfoActivity::class.java)
-                intent.putExtra("memberId", item.userId)
-                this.context.startActivity(intent)
+
+        if (itemClick != null) {
+            holder.itemView.setOnClickListener {
+                itemClick?.onClick(it, position, item.userId)
             }
         }
+//        holder.itemView.apply {
+//            //todo 근데 본인일때는 어케 알고 처리를 하지?
+//            setOnClickListener { view ->
+//                val intent = Intent(this.context, OtherInfoActivity::class.java)
+//                intent.putExtra("memberId", item.userId)
+//                this.context.startActivity(intent)
+//            }
+//        }
     }
 
     override fun getItemCount(): Int = applicantList.size

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/thunder/list/view/ThunderListActivity.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/thunder/list/view/ThunderListActivity.kt
@@ -16,9 +16,10 @@ import com.playtogether_android.app.presentation.ui.thunder.list.viewmodel.Thund
 import com.playtogether_android.app.presentation.ui.thunder.list.viewmodel.ThunderListViewModel.Companion.CATEGORY_EAT
 import com.playtogether_android.app.presentation.ui.thunder.list.viewmodel.ThunderListViewModel.Companion.CATEGORY_GO
 import com.playtogether_android.app.presentation.ui.thunder.list.viewmodel.ThunderListViewModel.Companion.DEFAULT_SORT
-import com.playtogether_android.app.presentation.ui.thunder.list.viewmodel.ThunderListViewModel.Companion.LIKECNT
+import com.playtogether_android.app.presentation.ui.thunder.list.viewmodel.ThunderListViewModel.Companion.SCPCNT
 import com.playtogether_android.app.presentation.ui.thunder.viewmodel.ThunderViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class ThunderListActivity :
@@ -85,7 +86,7 @@ class ThunderListActivity :
                             initData(DEFAULT_SORT)
                         }
                         1 -> {
-                            initData(LIKECNT)
+                            initData(SCPCNT)
                         }
                     }
                     thunderListViewModel.setTabPosition(tab?.position!!)
@@ -160,13 +161,12 @@ class ThunderListActivity :
 
     @SuppressLint("SetTextI18n")
     private fun initData(sortType: String = DEFAULT_SORT) {
+        Timber.e("init data : $sortType")
         with(thunderListViewModel) {
             getLightCategoryList(CATEGORY_EAT, sortType)
             getLightCategoryList(CATEGORY_GO, sortType)
             getLightCategoryList(CATEGORY_DO, sortType)
         }
-        thunderViewModel.getApplyList()
-        thunderViewModel.getOpenList()
     }
 
     private fun setBackButtonListener() {

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/thunder/list/viewmodel/ThunderListViewModel.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/thunder/list/viewmodel/ThunderListViewModel.kt
@@ -135,7 +135,7 @@ class ThunderListViewModel @Inject constructor(
 
     companion object {
         const val DEFAULT_SORT = "createdAt"
-        const val LIKECNT = "peopleCnt"
+        const val SCPCNT = "scpCnt"
         const val CATEGORY_EAT = "먹을래"
         const val CATEGORY_GO = "갈래"
         const val CATEGORY_DO = "할래"

--- a/app/src/main/java/com/playtogether_android/app/presentation/ui/userInfo/viewmodel/UserInfoViewModel.kt
+++ b/app/src/main/java/com/playtogether_android/app/presentation/ui/userInfo/viewmodel/UserInfoViewModel.kt
@@ -63,7 +63,7 @@ class UserInfoViewModel @Inject constructor(
         kotlin.runCatching { userInfoRepository.getOtherInfo(crewId, memberId) }
             .onSuccess {
                 _otherInfoData.postValue(it)
-                Timber.d("getOtherInfo-server 성공 : $it")
+                Timber.e("getOtherInfo-server 성공 : $it")
             }
             .onFailure {
                 it.printStackTrace()

--- a/app/src/main/java/com/playtogether_android/app/util/ViewExt.kt
+++ b/app/src/main/java/com/playtogether_android/app/util/ViewExt.kt
@@ -65,9 +65,9 @@ fun Context.stringListBuilder(context: Context, stringList: List<String?>): Stri
     val sb = StringBuilder()
 
     for (it in stringList) {
-        if (it.isNullOrBlank()) {
+        if (it.isNullOrEmpty()) {
             sb.append("미정")
-        } else if (it == "-1") {
+        } else if (it == "0") {
             sb.append(context.getString(R.string.createthunder_infinite))
         } else {
             sb.append(it)

--- a/app/src/main/res/layout/activity_create_thunder.xml
+++ b/app/src/main/res/layout/activity_create_thunder.xml
@@ -564,6 +564,7 @@
                         android:gravity="top"
                         android:hint="@string/createthunder_explaination"
                         android:includeFontPadding="false"
+                        android:maxLength="200"
                         android:minLines="11"
                         android:paddingHorizontal="10dp"
                         android:paddingVertical="20dp"

--- a/app/src/main/res/layout/activity_thunder_detail.xml
+++ b/app/src/main/res/layout/activity_thunder_detail.xml
@@ -41,7 +41,8 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                app:layout_constraintTop_toTopOf="parent"
+                tools:visibility="visible">
 
                 <TextView
                     android:id="@+id/tv_thunderdetail_apply"
@@ -92,7 +93,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/pretendard_bold"
-                    android:text="@{detailData.peopleCnt==-1 ? @string/createthunder_infinite : String.valueOf(detailData.peopleCnt)}"
+                    android:text="@{detailData.peopleCnt==0 ? @string/createthunder_infinite : String.valueOf(detailData.peopleCnt)}"
                     android:textColor="@color/gray_black"
                     android:textSize="16dp"
                     app:layout_constraintBottom_toBottomOf="@id/tv_thunderdetail_apply"
@@ -546,7 +547,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:fontFamily="@font/pretendard_bold"
-                            android:text="@{detailData.peopleCnt==-1 ? @string/createthunder_infinite : String.valueOf(detailData.peopleCnt)}"
+                            android:text="@{detailData.peopleCnt==0 ? @string/createthunder_infinite : String.valueOf(detailData.peopleCnt)}"
                             android:textColor="@color/gray_black"
                             android:textSize="16dp"
                             app:layout_constraintStart_toEndOf="@id/tv_applicant_slash"

--- a/app/src/main/res/layout/activity_thunder_detail.xml
+++ b/app/src/main/res/layout/activity_thunder_detail.xml
@@ -41,8 +41,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:visibility="visible">
+                app:layout_constraintTop_toTopOf="parent">
 
                 <TextView
                     android:id="@+id/tv_thunderdetail_apply"
@@ -496,7 +495,7 @@
                     android:id="@+id/cl_detail_organizer_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="visible"
+                    android:visibility="gone"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/cl_detail_boundary">
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -136,6 +136,7 @@
                             android:id="@+id/view_home_under_line"
                             android:layout_width="match_parent"
                             android:layout_height="1dp"
+                            android:layout_marginHorizontal="20dp"
                             android:layout_marginTop="31dp"
                             android:background="@color/gray_gray03"
                             app:layout_constraintTop_toBottomOf="@id/tv_home_eat" />

--- a/app/src/main/res/layout/fragment_tab_apply.xml
+++ b/app/src/main/res/layout/fragment_tab_apply.xml
@@ -49,7 +49,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:gravity="center"
-                    android:text="@string/home_empty_text"
+                    android:text="@string/apply_empty"
                     android:visibility="@{viewModel.thunderApplyList.size()==0 ? View.VISIBLE : View.INVISIBLE}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_tab_like.xml
+++ b/app/src/main/res/layout/fragment_tab_like.xml
@@ -49,7 +49,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:gravity="center"
-                    android:text="@string/home_empty_text"
+                    android:text="@string/like_empty"
                     android:visibility="@{viewModel.thunderLikeList.size()==0 ? View.VISIBLE : View.INVISIBLE}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_tab_open.xml
+++ b/app/src/main/res/layout/fragment_tab_open.xml
@@ -48,7 +48,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:gravity="center"
-                android:text="@string/home_empty_text"
+                android:text="@string/open_empty"
                 android:visibility="@{viewModel.thunderOpenList.size()==0 ? View.VISIBLE : View.INVISIBLE}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_home_hot.xml
+++ b/app/src/main/res/layout/item_home_hot.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="categoryData"
             type="com.playtogether_android.domain.model.light.CategoryData" />
@@ -19,9 +20,11 @@
         <TextView
             android:id="@+id/tv_homenew_title"
             style="@style/home_item_title"
-            android:text="@{categoryData.title}"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="25dp"
+            android:text="@{categoryData.title}"
+            app:layout_constraintEnd_toStartOf="@id/ll_itemhome"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="@string/home_item_title" />
@@ -34,7 +37,7 @@
             android:gravity="center"
             android:orientation="horizontal"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_homenew_title">
+            app:layout_constraintTop_toTopOf="parent">
 
             <TextView
                 android:id="@+id/tv_itemhome_category"
@@ -51,10 +54,11 @@
             style="@style/home_item_about"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="30dp"
+            android:layout_marginTop="52dp"
+            android:layout_marginBottom="15dp"
             android:text="@string/home_item_tool_people_cnt"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_homenew_title" />
+            app:layout_constraintTop_toBottomOf="@id/ll_itemhome" />
 
         <TextView
             android:id="@+id/tv_homenew_date"

--- a/app/src/main/res/layout/item_home_new.xml
+++ b/app/src/main/res/layout/item_home_new.xml
@@ -4,12 +4,14 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="categoryData"
             type="com.playtogether_android.domain.model.light.CategoryData" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_hot_item_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/rectangle_fill_gray_black_radius_10"
@@ -18,9 +20,11 @@
         <TextView
             android:id="@+id/tv_homenew_title"
             style="@style/home_item_title"
-            android:text="@{categoryData.title}"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:text="@{categoryData.title}"
+            app:layout_constraintEnd_toStartOf="@id/ll_itemhome"
+            android:layout_marginEnd="25dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="@string/home_item_title" />
@@ -29,39 +33,41 @@
             android:id="@+id/ll_itemhome"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
             android:background="@drawable/ic_rectangle_category_button"
             android:gravity="center"
             android:orientation="horizontal"
-            app:layout_constraintTop_toTopOf="@id/tv_homenew_title">
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <TextView
+                android:id="@+id/tv_itemhome_category"
                 style="@style/home_item_btn_text"
                 android:layout_width="wrap_content"
-                android:layout_gravity="center"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center"
                 android:text="@{categoryData.category}" />
 
         </LinearLayout>
 
         <TextView
             android:id="@+id/tv_homenew_people_cnt"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_homenew_title"
-            android:layout_marginTop="30dp"
+            style="@style/home_item_about"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="52dp"
+            android:layout_marginBottom="15dp"
             android:text="@string/home_item_tool_people_cnt"
-            style="@style/home_item_about" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ll_itemhome" />
 
         <TextView
-            android:layout_width="wrap_content"
-            style="@style/home_item_about"
-            android:text="@string/home_item_tool_date"
-            android:layout_height="wrap_content"
             android:id="@+id/tv_homenew_date"
+            style="@style/home_item_about"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/home_item_tool_date"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_homenew_people_cnt"/>
+            app:layout_constraintTop_toTopOf="@id/tv_homenew_people_cnt" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_thunder_list.xml
+++ b/app/src/main/res/layout/item_thunder_list.xml
@@ -82,7 +82,8 @@
             android:layout_height="wrap_content"
             android:background="@{categoryData.open ? @drawable/ic_icn_like_filled : @drawable/ic_icn_like_unfilled}"
             app:layout_constraintBottom_toBottomOf="@id/tv_thunder_item_limit_count"
-            app:layout_constraintStart_toStartOf="@id/ll_thunder_item_tag_container"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginEnd="46dp"
             app:layout_constraintTop_toTopOf="@id/tv_thunder_item_limit_count"
             tools:background="@drawable/ic_icn_like_filled" />
 
@@ -94,9 +95,10 @@
             android:layout_marginStart="2dp"
             android:text="@{String.valueOf(categoryData.likeCount)}"
             app:layout_constraintBottom_toBottomOf="@id/iv_thunder_item_fill_like"
-            app:layout_constraintStart_toEndOf="@id/iv_thunder_item_fill_like"
+            android:layout_marginEnd="20dp"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/iv_thunder_item_fill_like"
-            tools:text="123" />
+            tools:text="3" />
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,6 @@
     <string name="createthunder_date_undecided">날짜 미정</string>
 
 
-
     <!--signIn-->
     <string name="text_signin">로그인</string>
     <string name="signin_main_message">함께 놀아요! \nPLAY TOGETHER</string>
@@ -111,6 +110,9 @@
     <string name="tab_open">오픈한</string>
     <string name="tab_like">찜한</string>
     <string name="thunder_members">인원</string>
+    <string name="apply_empty">아직 신청한 번개가 없어요!\n관심 있는 번개를 신청해 보세요</string>
+    <string name="open_empty">아직 오픈한 번개가 없어요!\n새로운 번개를 오픈해 보세요</string>
+    <string name="like_empty">아직 찜한 번개가 없어요!\n관심 있는 번개를 찜 해보세요</string>
 
     <!-- onBoarding -->
     <string name="onboarding_user">님의</string>


### PR DESCRIPTION
## 😎️ 작업한 내용

- [x] 구글 로그인을 선택할 경우, 현재 갖고있는 구글 계정 중 어느걸 사용할지 고른 다음에 바로 메인뷰로 가버립니다 -> 그래서 프로필, 동아리 코드 입력 스텝을 점프해버리네요!
- [x] 번개 개설시, 상세 설명 항목에서 200자 이상 입력 후, 완료 버튼을 누를 때 무한 로딩이 지속되는 이슈 -> 번개 200자 제한을 안해서 그런듯
- [ ] 신청 완료 뷰, 또는 신청 완료한 번개 상세보기에서 참여자들 목록 중 참여자 프로필을 눌렀을 때 액션이 없습니다 -> Adapter에다가 click Listener를 달아야할듯 -> 기능은 달았으나 본인을 구별하는 조건이 없어 Preference에다가 userId를 저장해야할거같다.
- [x] 동아리 이름이 안뜬다 ? -> 어디에서 연결이 안되는지 확인해야 할 거 같다 -> 자동 로그인 문제로 로그아웃할때 preference정보를 초기화 시키면 해당 문제는 사라진다.
- [ ] 동의 항목 링크 연결 -> Notion링크 설정 -> 노션 문의
- [x] 글을 많이 입력해서인지… 중간에 공백이 생겨요.. 홈 카드에서도 뭔가 공백이 생겨요.. -> 정원센세가 나중에 수정해준다고 함
- [x] 신청 완료시 (2/ )와 같이 참여할 수 있는 인원 수가 공백 또는 0으로 표시됩니다 ->null 들어가있는거 어케 표시 하지? -> view 수정
- [x] 제목이 길 경우 메인뷰 카드에서 제목이 먹갈할 라벨에 가려요(잘린다고 해야하나..?) -> 라벨로 겹치지 않게 줄바꿈되어야한다고함 -> 뷰 수정
- [x] 홈 카드 날짜, 시간, 장소 사이 간격 설정이 안 되어 있습니다! -> 간격 설정 -> 뷰 수정
- [x] 리스트 카드 날짜 장소 인원 사이 “|”로 나눠져있어요
- [x] 번개 상세보기 사진이 첨부한 사이즈 그대로 사이즈만 줄어서 표시돼요 -> 정방형 + 라운드값 10으로 표시되어야 합니다! -> 이게 무슨 말인지? -> 기능 수정
- [x] 번개 리스트 카드 찜 하트 아이콘과 찜한 숫자가 왼쪽 기준으로 되어있어요! -> 오른쪽 마진 기준으로 맞춰주실 수 있으실까요..?ㅎㅎㅎ
- [x] 번개 카테고리와 HOT 사이 실선 양끝 마진이 없어요! -> 양끝 마진 20 있어야 합니다!
- [x] 신청한, 오픈한, 찜한 별로 엠티뷰 문구가 전달 드린 것과 달라요! -> 전달드린 문구들로 수정이 필요합니다!
- [ ] 동아리 이름이 길 때 텍스트가 잘려요! -> 동아리 이름이 길 때는 텍스트가 잘리지 않게 줄바꿈이 한 번 더 필요할 것 같습니다! -> 뷰 수정


## 👍 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- PR Point 1
- PR Point 2

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

## 💚 관련 이슈
- #254 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
